### PR TITLE
[RFC] Fix non-int id's

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,13 @@ function convertFieldsFromGlobalId(Model, data) {
     let attr = Model.rawAttributes[k];
     if (attr.references || attr.primaryKey) {
       let {id} = fromGlobalId(data[k]);
-      data[k] = parseInt(id);
+
+      // Check if id is numeric.
+      if(!_.isNaN(_.toNumber(id))) {
+          data[k] = parseInt(id);
+      } else {
+          data[k] = id;
+      }
     }
   });
 }


### PR DESCRIPTION
Hello @Glavin001 

I came across this when I wanted to use UUID's for primary keys. 

Since L109 converts all id's to integers, UUID's get converted to a number or NaN (depending on what the UUID is), causing Postgres to throw the following error;

`operator does not exist: uuid = integer`

Lodash is really good at identifying wether a string contains a number or not, so replacing the assign at L109 with the conditional I believe makes sense.
