### PR TITLE
add support for simple exlusion of fields from the generated graphql schemas

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -133,6 +133,7 @@ function _createRecord({
     description: `Create ${Model.name} record.`,
     inputFields: () => {
       let fields = attributeFields(Model, {
+        exclude: Model.excludeFields ? Model.excludeFields : [],
         commentToDescription: true,
         // exclude: [Model.primaryKeyAttribute],
         cache
@@ -260,6 +261,7 @@ function _updateRecords({
     description: `Update multiple ${Model.name} records.`,
     inputFields: () => {
       let fields = attributeFields(Model, {
+        exclude: Model.excludeFields ? Model.excludeFields : [],
         commentToDescription: true,
         allowNull: true,
         cache
@@ -405,6 +407,7 @@ function _updateRecord({
     description: `Update a single ${Model.name} record.`,
     inputFields: () => {
       let fields = attributeFields(Model, {
+        exclude: Model.excludeFields ? Model.excludeFields : [],
         commentToDescription: true,
         allowNull: true,
         cache
@@ -533,6 +536,7 @@ function _deleteRecords({
     description: `Delete ${Model.name} records.`,
     inputFields: () => {
       let fields = attributeFields(Model, {
+        exclude: Model.excludeFields ? Model.excludeFields : [],
         commentToDescription: true,
         allowNull: true,
         cache
@@ -663,6 +667,7 @@ function getSchema(sequelize) {
         },
           // Attribute fields
           attributeFields(Model, {
+            exclude: Model.excludeFields ? Model.excludeFields : [],
             globalId: true,
             commentToDescription: true,
             cache
@@ -778,6 +783,7 @@ function getSchema(sequelize) {
           let aModel = association.through.model;
           // console.log('BelongsToMany model', aModel);
           edgeFields = attributeFields(aModel, {
+            exclude: aModel.excludeFields ? aModel.excludeFields : [],
             globalId: true,
             commentToDescription: true,
             cache


### PR DESCRIPTION
In the future I imagine you might want to support all the options from the `graphql-sequelize` library with a more stable api, but until then this quick hack might be useful for others as well.

example usage:

``` js
    sequelize.models.user.excludeFields = ['password'];
    getSchema(sequelize);
```
