### PR TITLE
Remove fromGlobalId call

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,7 @@ function convertFieldsFromGlobalId(Model, data) {
     // Check if reference attribute
     let attr = Model.rawAttributes[k];
     if (attr.references || attr.primaryKey) {
-      let id = data[k];
+      let id = (data[k] !== null && typeof data[k] === 'object')?fromGlobalId(data[k]).id:data[k];
 
       // Check if id is numeric.
       if(!_.isNaN(_.toNumber(id))) {

--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,7 @@ function convertFieldsFromGlobalId(Model, data) {
     // Check if reference attribute
     let attr = Model.rawAttributes[k];
     if (attr.references || attr.primaryKey) {
-      let {id} = fromGlobalId(data[k]);
+      let id = data[k];
 
       // Check if id is numeric.
       if(!_.isNaN(_.toNumber(id))) {


### PR DESCRIPTION
This code work at least without relay
I don't have a clue on what `fromGlobalId` is for, but at least I found that `data[k]` will be a primitive data type and calling `fromGlobalId(data[k])` will be resulting in undefined. Hence I just remove the call and directly put `id=data[k]` at that position. If `fromGlobalId` call is critical to relay support, we may have to detect whether we are running with relay and put `let id = runningOnRelay?fromGlobalId(data[k]).id:data[k]` there.
partial fix #29 , should work without relay